### PR TITLE
Feature: improved coding standard

### DIFF
--- a/src/MediactMagento2/ruleset.xml
+++ b/src/MediactMagento2/ruleset.xml
@@ -17,12 +17,7 @@
         <exclude name="MediactCommon.Php7.ReturnType" />
         <exclude name="Squiz.Commenting.FunctionComment.TypeHintMissing" />
         <exclude name="PSR2.Methods.MethodDeclaration.Underscore" />
-        <exclude name="PSR2.Classes.PropertyDeclaration.Underscore" />
         <exclude name="Squiz.Commenting.FunctionComment.EmptyThrows" />
-        <exclude name="Generic.Formatting.MultipleStatementAlignment.NotSameWarning" />
-        <exclude name="Generic.Commenting.DocComment.TagValueIndent" />
-        <exclude name="Squiz.Commenting.FunctionComment.SpacingAfterParamType" />
-        <exclude name="Generic.PHP.Syntax"/>
     </rule>
 
     <rule ref="Generic.Files.LineLength.TooLong">

--- a/src/MediactMagento2/ruleset.xml
+++ b/src/MediactMagento2/ruleset.xml
@@ -35,4 +35,7 @@
     <rule ref="Generic.CodeAnalysis.ForLoopWithTestFunctionCall.NotAllowed">
         <exclude-pattern>*.phtml</exclude-pattern>
     </rule>
+    <rule ref="PSR2.Classes.PropertyDeclaration.Underscore">
+        <exclude-pattern>*.phtml</exclude-pattern>
+    </rule>
 </ruleset>


### PR DESCRIPTION
In this commit the coding standard is adjusted to be more strict.

- Property declaration starting with an underscore is not allowed anymore, because the classes that are written internally should always abide to this standard.
- The stricter indentation rules will make the overall code look cleaner and be more readable.
- The generic syntax rule is for verifying that the code at least works.