### PR TITLE
1.6.0 PSR12 Remove control structure spacing sniff, bump requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
     }
   ],
   "require": {
-    "mediact/coding-standard": "@stable"
+    "mediact/coding-standard": "^3.0",
+    "squizlabs/php_codesniffer": "^3.5"
   },
   "autoload": {
     "psr-0": {

--- a/src/MediactMagento2/ruleset.xml
+++ b/src/MediactMagento2/ruleset.xml
@@ -29,9 +29,6 @@
     <rule ref="Squiz.WhiteSpace.ScopeClosingBrace">
         <exclude-pattern>*.phtml</exclude-pattern>
     </rule>
-    <rule ref="Squiz.WhiteSpace.ControlStructureSpacing">
-        <exclude-pattern>*.phtml</exclude-pattern>
-    </rule>
     <rule ref="Generic.CodeAnalysis.ForLoopWithTestFunctionCall.NotAllowed">
         <exclude-pattern>*.phtml</exclude-pattern>
     </rule>


### PR DESCRIPTION
The stable requirement has been replaced by ^3.0 to force the PSR12
standard. PHPCS ^3.5 has been required because it includes the used
ReturnTypeDeclaration sniff.

The control structure sniff conflicts with PSR12 so it has been removed.